### PR TITLE
Fixed "get() on array" and "undefined method stdClass::get()"

### DIFF
--- a/src/ShiprocketApi.php
+++ b/src/ShiprocketApi.php
@@ -45,8 +45,13 @@ class ShiprocketApi
      */
     public function getToken($credentials = null)
     {
-        return $this->auth($this->client, $credentials)
-            ->get('token');
+            $data = $this->auth($this->client, $credentials);
+
+            if (isset($data->token)) return $data->token;
+
+            if (isset($data['token'])) return $data['token'];
+            
+            return $data->get('token');
     }
 
     /**


### PR DESCRIPTION
I noticed that using `responseType` other than `collection` causes one of these errors 

For responseType `array` Error: `get() on array`
and for `object` Error: `undefined method stdClass::get()`

As it was hardcoded on the `getToken` method to use laravel's `get` helper, which is a collection helper and doesn't work with `Arrays` or `Objects`. 
So using responseType other than Collection was causing this error.

I'm sure there would be more clean way of doing this, I'm a noob (this is my first ever PR)
I'm very anxious of breaking things. 

One more thing I wanna mention, it could've been a oneliner but I haven't used ?? (null coalescing operator) for older PHP versions support.

